### PR TITLE
PN-13836 Add SQS queue stack for antivirus transformation

### DIFF
--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -96,10 +96,6 @@ Parameters:
     Default: 'safeStorageObjectPutAndGetTracing'
     Description: 'Destination path into bucket name'
 
-  PnSsQueueTransformationAntivirusQueueArn:
-    Type: String
-    Description: 'ARN della coda di trasformazione transformation'
-
 #### Parametri provenienti dal Template della Stack SS-Storage ####
   PnSsTableNameAnagraficaClient:
     Type: String

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -96,10 +96,6 @@ Parameters:
     Default: 'safeStorageObjectPutAndGetTracing'
     Description: 'Destination path into bucket name'
 
-  PnSsQueueTransformationAntivirusQueueName:
-    Type: String
-    Description: 'Nome della coda di trasformazione antivirus'
-
   PnSsQueueTransformationAntivirusQueueArn:
     Type: String
     Description: 'ARN della coda di trasformazione transformation'

--- a/scripts/aws/cfn/microservice.yml
+++ b/scripts/aws/cfn/microservice.yml
@@ -96,6 +96,14 @@ Parameters:
     Default: 'safeStorageObjectPutAndGetTracing'
     Description: 'Destination path into bucket name'
 
+  PnSsQueueTransformationAntivirusQueueName:
+    Type: String
+    Description: 'Nome della coda di trasformazione antivirus'
+
+  PnSsQueueTransformationAntivirusQueueArn:
+    Type: String
+    Description: 'ARN della coda di trasformazione transformation'
+
 #### Parametri provenienti dal Template della Stack SS-Storage ####
   PnSsTableNameAnagraficaClient:
     Type: String
@@ -717,6 +725,7 @@ Resources:
             Resource:
               - !Ref PnSsQueueArnStagingBucket
               - !Ref PnSsQueueArnAvailability
+              - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:pn-ss-transformation*queue'sch
           - Effect: Allow
             Sid: 'ReadFromSecretsManagerFirmaPEC'
             Action:

--- a/scripts/aws/cfn/storage.yml
+++ b/scripts/aws/cfn/storage.yml
@@ -806,10 +806,6 @@ Resources:
 
 
 Outputs:
-  PnSsQueueTransformationAntivirusQueueName:
-    Description: 'Nome della coda di trasformazione antivirus'
-    Value: !GetAtt PnSsQueueTransformationAntivirusStack.Outputs.QueueName
-
   PnSsQueueTransformationAntivirusQueueArn:
     Description: 'ARN della coda di trasformazione transformation'
     Value: !GetAtt PnSsQueueTransformationAntivirusStack.Outputs.QueueArn

--- a/scripts/aws/cfn/storage.yml
+++ b/scripts/aws/cfn/storage.yml
@@ -610,7 +610,7 @@ Resources:
         MaxReceiveCount: 10
         HasDLQ: True
         VisibilityTimeout: 300
-        QueueHasAlarm: 'false'
+        QueueHasAlarm: 'true'
         AlarmSNSTopicName: !Ref AlarmSNSTopicName
 
 ########### GESTORE BUCKET INVOKE DLQ ###########
@@ -806,6 +806,14 @@ Resources:
 
 
 Outputs:
+  PnSsQueueTransformationAntivirusQueueName:
+    Description: 'Nome della coda di trasformazione antivirus'
+    Value: !GetAtt PnSsQueueTransformationAntivirusStack.Outputs.QueueName
+
+  PnSsQueueTransformationAntivirusQueueArn:
+    Description: 'ARN della coda di trasformazione transformation'
+    Value: !GetAtt PnSsQueueTransformationAntivirusStack.Outputs.QueueArn
+
   PnSsTableNameAnagraficaClient:
     Description: 'Nome della tabella SS Anagrafica Client'
     Value: !Ref PnSsTableAnagraficaClient

--- a/scripts/aws/cfn/storage.yml
+++ b/scripts/aws/cfn/storage.yml
@@ -597,6 +597,22 @@ Resources:
               StringEquals:
                 AWS:SourceAccount: !Ref AWS::AccountId
 
+  ########### CODA SQS STANDARD PER ANTIVIRUS ###########
+  PnSsQueueTransformationAntivirusStack:
+    Type: AWS::CloudFormation::Stack
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+    Properties:
+      TemplateURL: !Sub '${TemplateBucketBaseUrl}/fragments/sqs-queue.yaml'
+      Parameters:
+        QueueName: 'pn-ss-transformation-antivirus-queue'
+        SqsManagedSseEnabled: true
+        MaxReceiveCount: 10
+        HasDLQ: True
+        VisibilityTimeout: 300
+        QueueHasAlarm: 'false'
+        AlarmSNSTopicName: !Ref AlarmSNSTopicName
+
 ########### GESTORE BUCKET INVOKE DLQ ###########
 # La coda PnSsQueueGestoreBucketInvokeErrors è la DLQ configurata per la risorsa Gestore Bucket (Lambda) #
   PnSsQueueGestoreBucketInvokeErrorsStack:

--- a/scripts/aws/cfn/storage.yml
+++ b/scripts/aws/cfn/storage.yml
@@ -597,22 +597,6 @@ Resources:
               StringEquals:
                 AWS:SourceAccount: !Ref AWS::AccountId
 
-  ########### CODA SQS STANDARD PER ANTIVIRUS ###########
-  PnSsQueueTransformationAntivirusStack:
-    Type: AWS::CloudFormation::Stack
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
-    Properties:
-      TemplateURL: !Sub '${TemplateBucketBaseUrl}/fragments/sqs-queue.yaml'
-      Parameters:
-        QueueName: 'pn-ss-transformation-antivirus-queue'
-        SqsManagedSseEnabled: true
-        MaxReceiveCount: 10
-        HasDLQ: True
-        VisibilityTimeout: 300
-        QueueHasAlarm: 'true'
-        AlarmSNSTopicName: !Ref AlarmSNSTopicName
-
 ########### GESTORE BUCKET INVOKE DLQ ###########
 # La coda PnSsQueueGestoreBucketInvokeErrors è la DLQ configurata per la risorsa Gestore Bucket (Lambda) #
   PnSsQueueGestoreBucketInvokeErrorsStack:
@@ -806,10 +790,6 @@ Resources:
 
 
 Outputs:
-  PnSsQueueTransformationAntivirusQueueArn:
-    Description: 'ARN della coda di trasformazione transformation'
-    Value: !GetAtt PnSsQueueTransformationAntivirusStack.Outputs.QueueArn
-
   PnSsTableNameAnagraficaClient:
     Description: 'Nome della tabella SS Anagrafica Client'
     Value: !Ref PnSsTableAnagraficaClient


### PR DESCRIPTION
Introduced a new CloudFormation stack for an antivirus transformation SQS queue. This includes properties for SSE, DLQ, visibility timeout, and alarms. Retention policies are set to ensure stack persistence.