### PR TITLE
PN-13837 Add S3:ObjectTagging:Put event configuration to bucket

### DIFF
--- a/scripts/aws/cfn/storage.yml
+++ b/scripts/aws/cfn/storage.yml
@@ -513,6 +513,13 @@ Resources:
         QueueConfigurations:
           - Event: 's3:ObjectCreated:*'
             Queue: !GetAtt PnSsQueueGestoreBucketInvokeStack.Outputs.QueueARN
+          - Event: 's3:ObjectTagging:Put'
+            Queue: !GetAtt PnSsQueueTransformationAntivirusStack.Outputs.QueueARN
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: "prefix"
+                    Value: "ANTIVIRUS_"
       OwnershipControls:
         Rules:
           - ObjectOwnership: BucketOwnerEnforced


### PR DESCRIPTION
This commit adds a new S3 event notification for ObjectTagging:Put, sending events to the PnSsQueueTransformationAntivirusStack queue. A filter is applied to trigger only for objects with the "ANTIVIRUS_" prefix. This change enhances event handling for tag updates with specific prefixes.